### PR TITLE
Change tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,79 +8,89 @@ AutoDoorCtrlWebAPIPHP is the API we use to connect our Angular web app to our My
   * copy `.htaccess` and the folder `api` to /var/www/html
 ## Notes  
   * This API will not work without the use of a properly setup MySQL database. Point the API to the db by changing `servername`, `username`, `password`, and `dbname` in `index.php`
-  * This API will not work without two public/private keypairs. Point the API to these keys by changing `adminPublic`, `adminPrivate`, `userPublic`, and `userPrivate` in `index.php`
   * This API will not have email functionality without a SMTP server from which it can send mail. Point the API to this SMTP server by changing `mailServer` and `mailPort`, and change mailer preferences with `mailUsername`, `mailPassword`, and `mailSender`
   * If you get permissions errors, it may be helpful to change ownership of files to `www-data` by running `sudo chown www-data:www-data /var/www/html/* /var/www/keys/*`, assuming you are using default paths
+  * If an API call does not have an explicit return value, any data recieved should be ignored. Success or failure will be communicated through HTTP status codes
 
 ## API Calls
-Users are JSON objects in the form `{"Status": "Active|Request", "RCSid": <RCSid>}`
+User objects returned by the API  are JSON objects in the form `{"status": "active|request", "rcsid": <rcsid>}`
 
-Admins are JSON objects in the form `{"username": <username>, "password": <bcrypted password>}`
-
-Requests with a star (\*) require admin authentication, otherwise they will return a `401 Unauthorized` error. Authentication is handled by sending the header `Authorization: Bearer <JWT>` as part of the request, where `<JWT>` is the Json Web Token recieved during login. User JWTs are not valid for admin authentication.
+Requests with a star (\*) require admin authentication, otherwise they will return a `401 Unauthorized` error. Authentication is handled by sending the header `Authorization: Bearer <token>` as part of the request, where `<token>` is the token recieved during login. User tokens are not valid for admin authentication.
 
 Requests with a plus (+) require user authentication. Authentication is handled in the same manner as for admin. 
 
 ### GET requests
 * /api/active_user \*
-    * Returns an array of all Users where Status is `Active`
+    * Returns an array of all non-admin enabled Users
 * /api/inactive_user \*
-    * Returns an array of all Users where Status is `Request`
-* /api/addAll \*
+    * Returns an array of all non-admin disabled Users
+* /api/add_all \*
     * Changes all Users' Status to `Active`
     * If email is enabled, sends an email to each User with changed status, informing them of the change and including a new temporary password
-    * Returns a throwaway value
-* /api/get-complaints \*
+* /api/get_complaints \*
     * Returns an array of JSON items in the form `{"location": <location>, "message": <message>}`
-* /api/get-doors
+* /api/get_doors
     * Returns an array of JSON items in the form `{"name": <name>, "location": <location>, "latitude": <latitude>, "longitude": <longitude>, "mac": <MACAdress>}`
-* /api/renew-token \*/+
-    * Returns a JSON object in the form `{"SESSIONID": <JWT>}` where `<JWT>` is a signed JSON web token with `sub` field matching `sub` field of token used to authenticate. Additionally, `<JWT>` will be signed with the same key as the token used to authenticate, so both users and admins can use this call. If authentication fails, `<JWT>` will be an empty string `""` 
-* /api/forgot-password
-    * Supply a GET parameter `token` containing a reset token (can be recovered from email sent by /api/forgot-password POST request)
+* /api/renew_token \*/+
+    * Extends the expiration deadline for the token used to authenticate
+    * Note that tokens with `reason = "forgot_passwd"` cannot be renewed
+* /api/forgot_password
+    * Supply a GET parameter `token` containing a reset token (can be recovered from email sent by /api/forgot_password POST request)
     * If token is valid, resets user password to a new temporary password
     * If email is enabled, sends an email to the user indicated by the token informing them of the password reset and including a new temporary password
 
 ### POST requests
 * /api/login
-    * Supply a JSON object in the form `{"RCSid": <RCSid>, "password": <password>}`
-    * Returns a JSON object in the form `{"SESSIONID": <JWT>}` where `<JWT>` is a signed JSON web token with `sub` field matching `<RCSID>`
-    * If `<RCSid>` and `<password>` do not together represent a valid active user, `<JWT>` will be an empty string `""`
-* /api/admin/login
-    * Supply a JSON object in the form `{"username": <username>, "password": <password>}`
-    * Returns a JSON object in the form `{"SESSIONID": <JWT>}` where `<JWT>` is a signed JSON web token with `sub` field matching `<username>`
-    * If `<username>` and `<password>` do not together represent a valid active user, `<JWT>` will be an empty string `""`
-* /api/request-access
-    * Supply a JSON object in the form `{"RCSid": <RCSid>}`
-    * Adds a row to Users with the values `{"Status": Request, "RCSid": <RCSid>}`
-    * If email is enabled, sends an email to `RCSid`@rpi.edu informing them they have been added to the waitlist
-    * Returns a throwaway value
-* /api/addtoActive \*
-    * Supply a JSON object in the form `{"RCSid": <RCSid>}`
-    * Changes the status of User with RCSid `<RCSid>` to `Active`
-    * If email is enabled, sends an email to `RCSid`@rpi.edu, informing them that their account is now active and including a new temporary password
-    * Returns a throwaway value
+    * Supply a JSON object in the form `{"rcsid": <rcsid>, "password": <password>}`
+    * Returns a JSON object in the form `{"SESSIONID": <token>}` where `<token>` is used to identify this user during future API interactions
+    * If `<RCSid>` and `<password>` do not together represent a valid active user, `<token>` will be an empty string `""`
+* /api/request_access
+    * Supply a JSON object in the form `{"rcsid": <rcsid>}`
+    * Adds a row to Users with the values `{"rcsid": <rcsid>, "password": "", "admin": FALSE, "enabled": FALSE}`
+    * If email is enabled, sends an email to `<rcsid>`@rpi.edu informing them they have been added to the waitlist
+* /api/add_to_active \*
+    * Supply a JSON object in the form `{"rcsid": <rcsid>}`
+    * Sets `enabled` to `TRUE` for the user with `rcsid` `<rcsid>`
+    * If email is enabled, sends an email to `<rcsid>`@rpi.edu, informing them that their account is now active and including a new temporary password
 * /api/remove \*
-    * Supply a JSON object in the form `{"RCSid": <RCSid>}`
-    * Deletes all Users with RCSid `<RCSid>`
-    * Returns a throwaway value
-* /api/submit-complaint
-    * Supply a JSON object in the form `{"Location": <location>, "Message": <message>}`
+    * Supply a JSON object in the form `{"rcsid": <rcsid>}`
+    * Deletes all non-admin users with rcsid `<rcsid>`
+* /api/submit_complaint
+    * Supply a JSON object in the form `{"location": <location>, "message": <message>}`
     * Stores the complaint in the server
-    * Returns a throwaway value
-* /api/open-door +
-    * Supply a JSON object in the form `{"door": <doorname>}`
-    * Returns a JSON object in the form `{"TOTP": <TOTP>}` where <TOTP> is a one-time password which can be used to open the specified door.
- * /api/change-password
-    * Supply a JSON object in the form `{"RCSid": <RCSid>, "password": <password>, "newPassword": <newPassword>}`
-    * If supplied valid credentials, changes password for user `<RCSid>` from `<password>` to `<newPassword>`
-    * If email is enabled, sends an email to `RCSid`@rpi.edu informing them that their password has been changed, and instructing them to notify an admin if they were not the party who changed their password
-* /api/admin/change-password
-    * Supply a JSON object in the form `{"username": <username>, "password": <password>, "newPassword": <newPassword>}`
-    * If supplied valid credentials, changes password for admin `<username>` from `<password>` to `<newPassword>`
-* /api/reset-password *
-    * Supply a JSON object in the form `{"RCSid": <RCSid>, "newPassword": <newPassword>}`
-    * Changes the password of user `<RCSid>` to `<newPassword>`
-* /api/forgot-password
-    * Supply a JSON object in the form `{"RCSid": <RCSid>}`
-    * If email is enabled and `RCSid` represents a valid active user, sends an email to `RCSid`@rpi.edu with a reset link containing an authentication token
+* /api/open_door +
+    * Supply a JSON object in the form `{"door": <name>}`
+    * Returns a JSON object in the form `{"totp": <totp>}` where <totp> is a 6 digit one-time password which can be used to open the specified door.
+ * /api/change_password
+    * Supply a JSON object in the form `{"rcsid": <rcsid>, "password": <current password>, "newpass": <new password>}`
+    * If supplied valid credentials, changes password for user `<rcsid>` from `<password>` to `<newPassword>`
+    * If email is enabled, sends an email to `rcsid`@rpi.edu informing them that their password has been changed, and instructing them to notify an admin if they were not the party who changed their password
+* /api/reset_password *
+    * Supply a JSON object in the form `{"rcsid": <rcsid>, "newpass": <new password>}`
+    * Changes the password of non-admin user `<rcsid>` to `<new password>`
+* /api/forgot_password
+    * Supply a JSON object in the form `{"rcsid": <rcsid>}`
+    * If email is enabled and `rcsid` represents a valid active user, sends an email to `rcsid`@rpi.edu with a reset link containing an authentication token
+
+### Database Setup
+This API interfaces with a MySQL database called `ADC` with the following tables:
+* `users`
+    * `rcsid VARCHAR(255)` Holds the rcsid of the user, the portion of an RPI email before the `@`
+    * `password VARCHAR(255)` Holds the bcrypt-ed password of the user
+    * `admin BOOLEAN` Set to TRUE if this user is an admin, FALSE otherwise
+    * `enabled BOOLEAN` Set to TRUE if this account is enabled, FALSE otherwise
+* `complaints`
+    * `location VARCHAR(255)` The location the complaint is regarding
+    * `message TEXT` The complaint itself
+* `doors`
+    * `name VARCHAR(255)` The name of the door
+    * `location VARCHAR(255)` The pretty name of the door. This should only be used for display purposes for the end user
+    * `latitude DECIMAL(10,8)` The latitude of the door
+    * `longitude DECIMAL(11,8)` The longitude of the door
+    * `key VARCHAR(255)` The 256 bit HMAC key used for TOTP generation for this door
+    * `mac VARCHAR(255)` The MAC address of the bluetooth module for this door
+* `tokens`
+    * `rcsid VARCHAR(255)` The RCSid this token can authenticate for
+    * `reason VARCHAR(255)` The reason this token was issued (defined values are "login" and "forgot_passwd")
+    * `expiration TIMESTAMP` The UTC timestamp after which this token is no longer valid
+    * `value VARCHAR(255)` The actual token value

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Requests with a plus (+) require user authentication. Authentication is handled 
     * Supply a GET parameter `token` containing a reset token (can be recovered from email sent by /api/forgot_password POST request)
     * If token is valid, resets user password to a new temporary password
     * If email is enabled, sends an email to the user indicated by the token informing them of the password reset and including a new temporary password
+* /api/logout
+    * If this request is made with a valid authentication token, the token is disabled and cannot be used for further requests
 
 ### POST requests
 * /api/login

--- a/README.md
+++ b/README.md
@@ -20,8 +20,10 @@ Requests with a star (\*) require admin authentication, otherwise they will retu
 Requests with a plus (+) require user authentication. Authentication is handled in the same manner as for admin. 
 
 ### GET requests
-* /api/get_users \*
-    * Returns an array of all non-admin Users
+* /api/active_user \*
+    * Returns an array of all non-admin active Users
+* /api/inactive_user \*
+    * Returns an array of all non-admin inactive Users
 * /api/add_all \*
     * Changes all Users' Status to `Active`
     * If email is enabled, sends an email to each User with changed status, informing them of the change and including a new temporary password

--- a/README.md
+++ b/README.md
@@ -13,17 +13,15 @@ AutoDoorCtrlWebAPIPHP is the API we use to connect our Angular web app to our My
   * If an API call does not have an explicit return value, any data recieved should be ignored. Success or failure will be communicated through HTTP status codes
 
 ## API Calls
-User objects returned by the API  are JSON objects in the form `{"status": "active|request", "rcsid": <rcsid>}`
+User objects returned by the API  are JSON objects in the form `{"rcsid": <rcsid>, "enabled": <boolean>}`
 
 Requests with a star (\*) require admin authentication, otherwise they will return a `401 Unauthorized` error. Authentication is handled by sending the header `Authorization: Bearer <token>` as part of the request, where `<token>` is the token recieved during login. User tokens are not valid for admin authentication.
 
 Requests with a plus (+) require user authentication. Authentication is handled in the same manner as for admin. 
 
 ### GET requests
-* /api/active_user \*
-    * Returns an array of all non-admin enabled Users
-* /api/inactive_user \*
-    * Returns an array of all non-admin disabled Users
+* /api/get_users \*
+    * Returns an array of all non-admin Users
 * /api/add_all \*
     * Changes all Users' Status to `Active`
     * If email is enabled, sends an email to each User with changed status, informing them of the change and including a new temporary password

--- a/api/authentication.php
+++ b/api/authentication.php
@@ -138,7 +138,8 @@ function login($user, $password)
 
 	$query = '
 	SELECT
-		password
+		password,
+		admin
 	FROM
 		users
 	WHERE
@@ -152,16 +153,17 @@ function login($user, $password)
 	if(mysqli_num_rows($result) == 0)
 	{
 		error_log("Failed login as " . $user . ": Bad rcsid");
-		return false;
+		return -1;
 	}
-	$hash = $result->fetch_assoc()['password'];
+	$row = $result->fetch_assoc();
+	$hash = $row['password'];
 	if(password_verify($password, $hash))
 	{
 		error_log("Successful login as " . $user);
-		return true;
+		return $row['admin'];
 	}
 	error_log("Failed login as " . $user . ": Bad password");
-	return false;
+	return -1;
 }
 
 function resetPassword($rcsid)

--- a/api/authentication.php
+++ b/api/authentication.php
@@ -1,0 +1,179 @@
+<?php
+//This file holds all of the functions to authenticate a user and generate
+//authentication material like tokens
+
+//Generates 16 bytes of hex encoded randomness
+function genRandom()
+{
+	return bin2hex(random_bytes(16));
+}
+
+//Checks if the current request is authenticated using a token
+function getToken()
+{
+	$headers = getallheaders();
+	//If the request did not pass an Authorization header,
+	//it is not authorized
+	if(!array_key_exists('Authorization', $headers))
+		return "";
+	//Requests should be prefixed with 'Bearer', this removes that
+	//to extract just the token
+	$authHeader = $headers['Authorization'];
+	$tokenString = substr($authHeader, 7);
+	return $tokenString;
+}
+
+function authenticate($reason, $tokenString)
+{
+	global $conn;
+
+	//Get the rcsid and admin status of the user associated with
+	//this token, checking that the account is enabled and the token
+	//is not expired
+	$query = '
+	SELECT
+		rcsid,
+		admin
+	FROM
+		users
+	WHERE
+		enabled = 1 AND
+		rcsid =
+		(
+			SELECT
+				rcsid
+			FROM
+				tokens
+			WHERE
+				expiration > UTC_TIMESTAMP AND
+				reason = ? AND
+				value = ?
+		);';
+
+	//Run the query
+	$statement = $conn->prepare($query);
+	$statement->bind_param('ss', $reason, $tokenString);
+	$statement->execute();
+	checkError();
+	$result = $statement->get_result();
+	//If we have a result, return it. Otherwise give back NULL
+	if($result && mysqli_num_rows($result) > 0)
+	{
+		return $result->fetch_assoc();
+	}
+	return NULL;
+}
+
+//Using an admin JWT
+function adminAuthenticate()
+{
+	$token = getToken();
+	//Try to authenticate the request, we succeed if the token is
+	//valid and if the token is for an admin
+	$userObj = authenticate("login", $token);
+	if($userObj == NULL || $userObj['admin'] != 1)
+	{
+		header("HTTP/1.1 401 Unauthorized");
+		echo "Unauthorized";
+		exit;
+	}
+	return $userObj['rcsid'];
+}
+
+//Using a user JWT
+function userAuthenticate()
+{
+	$token = getToken();
+	//Try to authenticate the request, we succeed if the token is
+	//valid for a user OR an admin
+	$userObj = authenticate("login", $token);
+	if($userObj == NULL)
+	{
+		header("HTTP/1.1 401 Unauthorized");
+		echo "Unauthorized";
+		exit;
+	}
+	return $userObj['rcsid'];
+}
+
+//Generate token for $user with duration $duration and upload it to the database
+function generateToken($rcsid, $reason, $duration)
+{
+	global $conn;
+
+	$token = genRandom();
+
+	//Get the rcsid and admin status of the user associated with
+	//this token, checking that the account is enabled and the token
+	//is not expired
+	$query = '
+	INSERT INTO
+		tokens
+		(
+			rcsid,
+			reason,
+			expiration,
+			value
+		)
+	VALUES
+	(
+		?,
+		?,
+		ADDDATE(UTC_TIMESTAMP, INTERVAL ? SECOND),
+		?
+	)';
+
+	//Run the query
+	$statement = $conn->prepare($query);
+	$statement->bind_param('ssis', $rcsid, $reason, $duration, $token);
+	$statement->execute();
+	checkError();
+	error_log("Token generated for " . $rcsid);
+	return $token;
+}
+
+function login($user, $password)
+{
+	global $conn;
+
+	$query = '
+	SELECT
+		password
+	FROM
+		users
+	WHERE
+		enabled = 1 AND
+		rcsid = ?';
+	$statement = $conn->prepare($query);
+	$statement->bind_param('s', $user);
+	$statement->execute();
+	checkError();
+	$result = $statement->get_result();
+	if(mysqli_num_rows($result) == 0)
+	{
+		error_log("Failed login as " . $user . ": Bad rcsid");
+		return false;
+	}
+	$hash = $result->fetch_assoc()['password'];
+	if(password_verify($password, $hash))
+	{
+		error_log("Successful login as " . $user);
+		return true;
+	}
+	error_log("Failed login as " . $user . ": Bad password");
+	return false;
+}
+
+function resetPassword($rcsid)
+{
+	global $conn;
+
+	$tempPass = genRandom();
+	$hash = password_hash($tempPass, PASSWORD_BCRYPT);
+	$statement = $conn->prepare('UPDATE users SET enabled = 1, password = ? WHERE rcsid = ?');
+	$statement->bind_param('ss', $hash, $rcsid);
+	$statement->execute();
+	checkError();
+	return $tempPass;
+}
+

--- a/api/composer.json
+++ b/api/composer.json
@@ -3,7 +3,6 @@
     "description": "The API that powers ADC clients",
     "type": "project",
     "require": {
-        "lcobucci/jwt": "^3.3",
         "spomky-labs/otphp": "^10.0",
         "phpmailer/phpmailer": "^6.1"
     },

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "b777910ae0d984ad952599606cd471b8",
+    "content-hash": "e079be8a25dfcc28b461820c5d8548ab",
     "packages": [
         {
             "name": "beberlei/assert",
@@ -60,61 +60,6 @@
                 "validation"
             ],
             "time": "2019-08-23T16:04:58+00:00"
-        },
-        {
-            "name": "lcobucci/jwt",
-            "version": "3.3.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/lcobucci/jwt.git",
-                "reference": "a11ec5f4b4d75d1fcd04e133dede4c317aac9e18"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/lcobucci/jwt/zipball/a11ec5f4b4d75d1fcd04e133dede4c317aac9e18",
-                "reference": "a11ec5f4b4d75d1fcd04e133dede4c317aac9e18",
-                "shasum": ""
-            },
-            "require": {
-                "ext-mbstring": "*",
-                "ext-openssl": "*",
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "mikey179/vfsstream": "~1.5",
-                "phpmd/phpmd": "~2.2",
-                "phpunit/php-invoker": "~1.1",
-                "phpunit/phpunit": "^5.7 || ^7.3",
-                "squizlabs/php_codesniffer": "~2.3"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.1-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Lcobucci\\JWT\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Luís Otávio Cobucci Oblonczyk",
-                    "email": "lcobucci@gmail.com",
-                    "role": "Developer"
-                }
-            ],
-            "description": "A simple library to work with JSON Web Token and JSON Web Signature",
-            "keywords": [
-                "JWS",
-                "jwt"
-            ],
-            "time": "2019-05-24T18:30:49+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -180,16 +125,16 @@
         },
         {
             "name": "phpmailer/phpmailer",
-            "version": "v6.1.3",
+            "version": "v6.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPMailer/PHPMailer.git",
-                "reference": "a25ae38e03de4ee4031725498a600012364787c7"
+                "reference": "c5e61d0729507049cec9673aa1a679f9adefd683"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/a25ae38e03de4ee4031725498a600012364787c7",
-                "reference": "a25ae38e03de4ee4031725498a600012364787c7",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/c5e61d0729507049cec9673aa1a679f9adefd683",
+                "reference": "c5e61d0729507049cec9673aa1a679f9adefd683",
                 "shasum": ""
             },
             "require": {
@@ -238,20 +183,20 @@
                 }
             ],
             "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
-            "time": "2019-11-21T09:37:46+00:00"
+            "time": "2019-12-10T11:17:38+00:00"
         },
         {
             "name": "spomky-labs/otphp",
-            "version": "v10.0.0",
+            "version": "v10.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Spomky-Labs/otphp.git",
-                "reference": "7c4e59c6a1cfe7798e5bf33cca6e5e5cdc5df9ff"
+                "reference": "f44cce5a9db4b8da410215d992110482c931232f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Spomky-Labs/otphp/zipball/7c4e59c6a1cfe7798e5bf33cca6e5e5cdc5df9ff",
-                "reference": "7c4e59c6a1cfe7798e5bf33cca6e5e5cdc5df9ff",
+                "url": "https://api.github.com/repos/Spomky-Labs/otphp/zipball/f44cce5a9db4b8da410215d992110482c931232f",
+                "reference": "f44cce5a9db4b8da410215d992110482c931232f",
                 "shasum": ""
             },
             "require": {
@@ -259,17 +204,17 @@
                 "ext-mbstring": "*",
                 "paragonie/constant_time_encoding": "^2.0",
                 "php": "^7.2|^8.0",
-                "thecodingmachine/safe": "^0.1.14"
+                "thecodingmachine/safe": "^0.1.14|^1.0"
             },
             "require-dev": {
                 "php-coveralls/php-coveralls": "^2.0",
-                "phpstan/phpstan": "^0.11",
-                "phpstan/phpstan-beberlei-assert": "^0.11.0",
-                "phpstan/phpstan-deprecation-rules": "^0.11",
-                "phpstan/phpstan-phpunit": "^0.11",
-                "phpstan/phpstan-strict-rules": "^0.11",
+                "phpstan/phpstan": "^0.12",
+                "phpstan/phpstan-beberlei-assert": "^0.12",
+                "phpstan/phpstan-deprecation-rules": "^0.12",
+                "phpstan/phpstan-phpunit": "^0.12",
+                "phpstan/phpstan-strict-rules": "^0.12",
                 "phpunit/phpunit": "^8.0",
-                "thecodingmachine/phpstan-safe-rule": "^0.1.0"
+                "thecodingmachine/phpstan-safe-rule": "^1.0"
             },
             "type": "library",
             "extra": {
@@ -309,29 +254,29 @@
                 "otp",
                 "totp"
             ],
-            "time": "2019-07-30T14:43:55+00:00"
+            "time": "2020-01-28T09:24:19+00:00"
         },
         {
             "name": "thecodingmachine/safe",
-            "version": "v0.1.16",
+            "version": "v1.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thecodingmachine/safe.git",
-                "reference": "4e8f840f0a0a2ea167813c3994a7fc527c3c2182"
+                "reference": "6662d0bef91fe5d44178cb2c38d51c5d16b65d23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/4e8f840f0a0a2ea167813c3994a7fc527c3c2182",
-                "reference": "4e8f840f0a0a2ea167813c3994a7fc527c3c2182",
+                "url": "https://api.github.com/repos/thecodingmachine/safe/zipball/6662d0bef91fe5d44178cb2c38d51c5d16b65d23",
+                "reference": "6662d0bef91fe5d44178cb2c38d51c5d16b65d23",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^0.10.3",
+                "phpstan/phpstan": "^0.12",
                 "squizlabs/php_codesniffer": "^3.2",
-                "thecodingmachine/phpstan-strict-rules": "^0.10.3"
+                "thecodingmachine/phpstan-strict-rules": "^0.12"
             },
             "type": "library",
             "extra": {
@@ -441,7 +386,7 @@
                 "MIT"
             ],
             "description": "PHP core functions that throw exceptions instead of returning FALSE on error",
-            "time": "2019-06-25T08:45:33+00:00"
+            "time": "2020-01-20T08:44:36+00:00"
         }
     ],
     "packages-dev": [],

--- a/api/constants.php
+++ b/api/constants.php
@@ -1,0 +1,22 @@
+<?php
+//Configuration variables that alter how the API integrates with the
+//mailer and database
+//
+//Holds the database connection information
+$servername = 'localhost';
+$username = 'developer';
+$password = 'developer';
+$dbname = 'ADC';
+
+//Holds the length of time in seconds for which a token is valid
+$userDuration = 259200; //72 hours
+$adminDuration = 86400; //24 hours
+$forgetPasswordDuration = 1800; //30 minutes
+
+//Holds SMTP connection info
+$mailServer = 'mail.rpiadc.com';
+$mailUsername = 'mailer';
+$mailPassword = 'password';
+$mailPort = 465;
+$mailSender = 'no-reply@rpiadc.com';
+?>

--- a/api/constants.php
+++ b/api/constants.php
@@ -9,9 +9,8 @@ $password = 'developer';
 $dbname = 'ADC';
 
 //Holds the length of time in seconds for which a token is valid
-$userDuration = 259200; //72 hours
-$adminDuration = 86400; //24 hours
-$forgetPasswordDuration = 1800; //30 minutes
+$loginDuration = 259200; //72 hours
+$forgotPasswordDuration = 1800; //30 minutes
 
 //Holds SMTP connection info
 $mailServer = 'mail.rpiadc.com';

--- a/api/database.php
+++ b/api/database.php
@@ -1,0 +1,62 @@
+<?php
+//This file is used to initialize the database connection and provide
+//a few database functions
+
+//Check if the connection has generated an error
+function checkError()
+{
+	global $conn;
+	//If we failed, tell them. Otherwise, success
+	if(mysqli_errno($conn))
+	{
+		header("HTTP/1.1 500 Internal Server Error");
+		error_log(mysqli_error($conn));
+		echo "Database Error";
+		exit;
+	}
+}
+
+function makeRequest($query)
+{
+	global $conn;
+	
+	//Make the request
+	$statement = $conn->prepare($query);
+	$statement->execute();
+	$result = $statement->get_result();
+	checkError();
+
+	//If we get back a boolean, we're done
+	if (gettype($result) == 'boolean')
+	{
+		return "";
+	}
+	//If we have results, send them as a JSON array. Otherwise,
+	//send back an empty array
+	$resultArr = [];
+	while($row = $result->fetch_assoc())
+	{
+		array_push($resultArr, $row);
+	}
+	return $resultArr;
+}
+
+function dumpRequest($query)
+{
+	//Output the result
+	header('Content-Type: application/json');
+	echo json_encode(makeRequest($query));
+}
+
+// Create connection
+$conn = mysqli_connect($servername, $username, $password, $dbname);
+
+// Check connection
+if (!$conn)
+{
+	header("HTTP/1.1 500 Internal Server Error");
+	error_log(mysqli_error($conn));
+	echo "Database Error";
+	exit;
+}
+?>

--- a/api/email.php
+++ b/api/email.php
@@ -1,0 +1,74 @@
+<?php
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\Exception;
+
+//This file provides helper functions for sending notification emails to users
+
+function confirmationEmail($rcsid)
+{
+	sendEmail($rscid . "@rpi.edu", "Welcome to ADC!", "We're currently processing your request, and we'll reach out to you as soon as possible. If you have any questions, please direct them to adc@rpiadc.com");
+	error_log("Sent confirmation email to " . $rcsid);
+}
+
+function activatedEmail($rcsid, $tempPass)
+{
+	sendEmail($rcsid . "@rpi.edu", "Congratulations!", "Your RPI ADC account is now active. Your temporary password is " . $tempPass . ". You can use it to login at https://rpiadc.com, and don't forget to change it once you've logged in!");
+	error_log("Sent activation email to " . $rcsid);
+}
+
+function passwordChangeEmail($rcsid)
+{
+	sendEmail($rcsid . "@rpi.edu", "Password Change Notification", "Someone (hopefully you) just changed your password. If it wasn't you, please let us know right away at webmaster@rpiadc.com");
+	error_log("Sent password change email to " . $rcsid);
+}
+
+function forgotPasswordEmail($rcsid)
+{
+	global $resetUserPrivate, $forgotPasswordDuration;
+
+	$forgotToken = generateToken($rcsid, "forgot-passwd", $forgotPasswordDuration);
+	sendEmail($rcsid . "@rpi.edu", "Password Reset", "Someone (hopefully you) just requested a new password on this account. If it was you, please click the following link: <a href='https://rpiadc.com/api/forgot-password?token=" . $forgotToken . "'>RESET PASSWORD</a>. If it wasn't you, please let us know right away at webmaster@rpiadc.com");
+	error_log("Sent forgot password email to " . $rcsid);
+}
+
+function resetPasswordEmail($rcsid, $tempPass)
+{
+	sendEmail($rcsid . "@rpi.edu", "Your Temporary Password", "Your password has been reset. Your temporary password is " . $tempPass . ". Please log in at https://rpiadc.com and change it as soon as possible");
+	error_log("Sent new password email to " . $rcsid);
+}
+
+function sendEmail($recipient, $subject, $message)
+{
+	global $mailServer, $mailUsername, $mailPassword, $mailPort, $mailSender;
+
+	$mail = new PHPMailer(true);
+	try
+	{
+		//Server settings
+		$mail->isSMTP();					// Send using SMTP
+		$mail->Host       = $mailServer;			// Set the SMTP server to send through
+		$mail->SMTPAuth   = true;				// Enable SMTP authentication
+		$mail->Username   = $mailUsername;			// SMTP username
+		$mail->Password   = $mailPassword;			// SMTP password
+		$mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;	// Enable TLS encryption; `PHPMailer::ENCRYPTION_SMTPS` also accepted
+		$mail->Port       = $mailPort ;				// TCP port to connect to
+
+		//Recipients
+		$mail->setFrom($mailSender);
+		$mail->addAddress($recipient);				// Add a recipient
+
+		// Content
+		$mail->isHTML(true);					// Set email format to HTML
+		$mail->Subject = $subject;
+		$mail->Body    = $message;
+
+		$mail->send();
+	}
+	catch (Exception $e)
+	{
+		header("HTTP/1.1 500 Internal Server Error");
+		echo "Mailer error";
+		error_log($mail->ErrorInfo);
+	}
+}
+?>

--- a/api/index.php
+++ b/api/index.php
@@ -32,7 +32,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET')
 		//Output the result
 		dumpRequest($query);
 		break;
-	case '/api/get_users':
+	case '/api/inactive_user':
 		adminAuthenticate();
 		$query = '
 		SELECT
@@ -41,7 +41,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET')
 			users
 		WHERE
 			admin = 0 AND
-			enabled = 1';
+			enabled = 0';
 		//Output the result
 		dumpRequest($query);
 		break;

--- a/api/index.php
+++ b/api/index.php
@@ -130,13 +130,14 @@ else if ($_SERVER['REQUEST_METHOD'] === 'POST')
 		header('Content-Type: application/json');
 		//If no such user exists, send back an empty SESSIONID
 		$token = "";
-		if(login($postData['rcsid'], $postData['password']))
+		$isAdmin = login($postData['rcsid'], $postData['password']);
+		if($isAdmin != -1)
 		{
 			//If this user exists, generate a JWT for client
 			$token = generateToken($postData['rcsid'], "login", $loginDuration);
 		}
 		//Send the token to the client
-		echo json_encode(["SESSIONID"=>$token]);
+		echo json_encode(["SESSIONID"=>$token, "admin"=>$isAdmin]);
 		break;
 	case '/api/request_access':
 		error_log("Access request with rcsid " . $postData['rcsid']);
@@ -198,7 +199,7 @@ else if ($_SERVER['REQUEST_METHOD'] === 'POST')
 		break;
 	case '/api/change_password':
 		//Check if credentials are correct
-		if(!login($postData['rcsid'], $postData['password']))
+		if(login($postData['rcsid'], $postData['password']) == -1)
 		{
 			echo "Bad credentials";
 			exit;

--- a/api/index.php
+++ b/api/index.php
@@ -19,16 +19,29 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET')
 	//decide which call we're actually making
 	switch($betterURI)
 	{
+	case '/api/active_user':
+		adminAuthenticate();
+		$query = '
+		SELECT
+			rcsid
+		FROM
+			users
+		WHERE
+			admin = 0 AND
+			enabled = 1';
+		//Output the result
+		dumpRequest($query);
+		break;
 	case '/api/get_users':
 		adminAuthenticate();
 		$query = '
 		SELECT
-			rcsid,
-			enabled
+			rcsid
 		FROM
 			users
 		WHERE
-			admin = 0';
+			admin = 0 AND
+			enabled = 1';
 		//Output the result
 		dumpRequest($query);
 		break;

--- a/api/index.php
+++ b/api/index.php
@@ -1,457 +1,103 @@
 <?php
 require __DIR__ . '/vendor/autoload.php';
-use Lcobucci\JWT\Builder;
-use Lcobucci\JWT\Signer\Key;
-use Lcobucci\JWT\Signer\Rsa\Sha256;
-use Lcobucci\JWT\Parser;
 use OTPHP\TOTP;
 
-use PHPMailer\PHPMailer\PHPMailer;
-use PHPMailer\PHPMailer\Exception;
-
-//Configuration variables
-//Holds the database connection information
-$servername = 'localhost';
-$username = 'developer';
-$password = 'developer';
-$dbname = 'users';
-//Holds the filesystem location of the four keys
-$adminPublic = '/var/www/keys/adminPublic.key';
-$adminPrivate = '/var/www/keys/adminPrivate.key';
-$userPublic = '/var/www/keys/userPublic.key';
-$userPrivate = '/var/www/keys/userPrivate.key';
-//Holds the length of time in seconds for which a token is valid
-$userDuration = 259200; //72 hours
-$adminDuration = 86400; //24 hours
-$forgetPasswordDuration = 1800; //30 minutes
-//Holds SMTP connection info
-$mailServer = 'mail.rpiadc.com';
-$mailUsername = 'mailer';
-$mailPassword = 'password';
-$mailPort = 465;
-$mailSender = 'no-reply@rpiadc.com';
+include 'constants.php';
+include 'database.php';
+include 'authentication.php';
+include 'email.php';
 
 header("Access-Control-Allow-Origin: *");
 header("Access-Control-Allow-Headers: authorization, content-type");
-
-//Checks if the current request is authenticated using $publicKey and JWT
-function authenticate($publicKeyFile)
-{
-	$publicKey = new Key('file://' . $publicKeyFile);
-	$headers = getallheaders();
-	//If the request did not pass an Authorization header,
-	//it is not authorized
-	if(!array_key_exists('Authorization', $headers))
-		return "";
-	//Requests should be prefixed with 'Bearer', this removes that
-	//to extract just the token
-	$authHeader = $headers['Authorization'];
-	$tokenString = substr($authHeader, 7);
-	return jwtAuthenticate($publicKeyFile, $tokenString);
-}
-
-function jwtAuthenticate($publicKeyFile, $tokenString)
-{
-	//Verify the token against the public key
-	$signer = new Sha256();
-	try
-	{
-		$token = (new Parser())->parse((string) $tokenString);
-	}
-	catch(InvalidArgumentException $e)
-	{
-		return "";
-	}
-	//If unauthorized, fail. Otherwise continue
-	if(!$token->verify($signer, $publicKey))
-		return "";
-	return $token->getClaim('sub');
-}
-
-//Using an admin JWT
-function adminAuthenticate()
-{
-	global $adminPublic;
-	$admin = authenticate($adminPublic);
-	if($admin == "")
-	{
-		header("HTTP/1.1 401 Unauthorized");
-		echo "Unauthorized";
-		exit;
-	}
-	return $admin;
-}
-
-//Using a user JWT
-function userAuthenticate()
-{
-	global $userPublic;
-	$user = authenticate($userPublic);
-	if($user == "")
-	{
-		header("HTTP/1.1 401 Unauthorized");
-		echo "Unauthorized";
-		exit;
-	}
-	return $user;
-}
-
-//Generate JWT with subject $subject that expires after $duration signed by $privateKeyFile
-function generateJWT($privateKeyFile, $subject, $duration)
-{
-	//We use RS256 for verification
-	$signer = new Sha256();
-	$time = time();
-	//Sign the JWT using the private key
-	$privateKey = new Key('file://' . $privateKeyFile);
-	$token = (new Builder())
-		->issuedAt($time) // Configures the time that the token was issue (iat claim)
-		->expiresAt($time + $duration) // Configures the expiration time of the token (exp claim)
-		->setSubject($subject) // Configures the subject of the token (sub claim)
-		->getToken($signer,  $privateKey); // Retrieves the generated token
-	error_log("Token generated for " . $subject . " with key " . $privateKeyFile);
-	return $token;
-}
-
-function userLogin($RCSid, $password)
-{
-	global $conn;
-	//Get the list of students with RCSid passed to us. List should
-	//be of length 0 or 1
-	$statement = $conn->prepare('SELECT * FROM students WHERE RCSid = ? AND STATUS = "Active"');
-	$statement->bind_param('s', $RCSid);
-	$statement->execute();
-	checkError();
-	$result = $statement->get_result();
-	if($result)
-	{
-		if(mysqli_num_rows($result) > 0)
-		{
-			$user = $result->fetch_assoc();
-			//Check the bcrypted password in DB against password passed to us
-			if(password_verify($password, $user['Password']))
-			{
-				error_log("Successful login as user " . $RCSid);
-				return true;
-			}
-			error_log("Failed login as user " . $RCSid . ": Bad password");
-			return false;
-		}
-		else
-		{
-			error_log("Failed login as user " . $RCSid . ": Bad RCSid");
-			return false;
-		}
-	}
-	else
-	{
-		header("HTTP/1.1 500 Internal Server Error");
-		error_log(mysqli_error($conn));
-		echo "Database Error";
-		exit;
-	}
-}
-
-function adminLogin($username, $password)
-{
-	global $conn;
-	//Get list of admin with username passed to us. List should be
-	//of length 0 or 1
-	$statement = $conn->prepare('SELECT * FROM admin WHERE username = ?');
-	$statement->bind_param('s', $username);
-	$statement->execute();
-	checkError();
-	$result = $statement->get_result();
-	if($result)
-	{
-		if(mysqli_num_rows($result) > 0)
-		{
-			$admin = $result->fetch_assoc();
-			//Check the bcrypted password in DB against password passed to us
-			if(password_verify($password, $admin['password']))
-			{
-				error_log("Successful login as admin " . $username);
-				return true;
-			}
-			else
-			{
-				error_log("Failed login as admin " . $username . ": Bad password");
-				return false;
-			}
-
-		}
-		else
-		{
-			error_log("Failed login as admin " . $username . ": Bad username");
-			return false;
-		}
-	}
-	else
-	{
-		header("HTTP/1.1 500 Internal Server Error");
-		error_log(mysqli_error($conn));
-		echo "Database Error";
-		exit;
-	}
-}
-
-function checkError()
-{
-	global $conn;
-	//If we failed, tell them. Otherwise, success
-	if(mysqli_errno($conn))
-	{
-		header("HTTP/1.1 500 Internal Server Error");
-		error_log(mysqli_error($conn));
-		echo "Database Error";
-		exit;
-	}
-}
-
-function genPassword()
-{
-	return bin2hex(random_bytes(16));
-}
-
-function confirmationEmail($RCSid)
-{
-	sendEmail($RCSid . "@rpi.edu", "Welcome to ADC!", "We're currently processing your request, and we'll reach out to you as soon as possible. If you have any questions, please direct them to adc@rpiadc.com");
-	error_log("Sent confirmation email to " . $RCSid);
-}
-
-function activatedEmail($RCSid, $tempPass)
-{
-	sendEmail($RCSid . "@rpi.edu", "Congratulations!", "Your RPI ADC account is now active. Your temporary password is " . $tempPass . ". You can use it to login at https://rpiadc.com, and don't forget to change it once you've logged in!");
-	error_log("Sent activation email to " . $RCSid);
-}
-
-function passwordChangeEmail($RCSid)
-{
-	sendEmail($RCSid . "@rpi.edu", "Password Change Notification", "Someone (hopefully you) just changed your password. If it wasn't you, please let us know right away at webmaster@rpiadc.com");
-	error_log("Sent password change email to " . $RCSid);
-}
-
-function forgotPasswordEmail($RCSid)
-{
-	global $resetUserPrivate, $forgotPasswordDuration;
-
-	$forgotToken = generateJWT($resetUserPrivate, $RCSid, $forgotPasswordDuration); 
-	sendEmail($RCSid . "@rpi.edu", "Password Reset", "Someone (hopefully you) just requested a new password on this account. If it was you, please click the following link: <a href='https://rpiadc.com/api/forgot-password?token=" . $forgotToken . "'>RESET PASSWORD</a>. If it wasn't you, please let us know right away at webmaster@rpiadc.com");
-	error_log("Sent forgot password email to " . $RCSid);
-}
-
-function resetPasswordEmail($RCSid, $tempPass)
-{
-	sendEmail($RCSid . "@rpi.edu", "Your Temporary Password", "Your password has been reset. Your temporary password is " . $tempPass . ". Please log in at https://rpiadc.com and change it as soon as possible");
-	error_log("Sent new password email to " . $RCSid);
-}
-
-function sendEmail($recipient, $subject, $message)
-{
-	global $mailServer, $mailUsername, $mailPassword, $mailPort, $mailSender;
-
-	$mail = new PHPMailer(true);
-	try
-	{
-		//Server settings
-		$mail->isSMTP();					// Send using SMTP
-		$mail->Host       = $mailServer;			// Set the SMTP server to send through
-		$mail->SMTPAuth   = true;				// Enable SMTP authentication
-		$mail->Username   = $mailUsername;			// SMTP username
-		$mail->Password   = $mailPassword;			// SMTP password
-		$mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;	// Enable TLS encryption; `PHPMailer::ENCRYPTION_SMTPS` also accepted
-		$mail->Port       = $mailPort ;				// TCP port to connect to
-
-		//Recipients
-		$mail->setFrom($mailSender);
-		$mail->addAddress($recipient);				// Add a recipient
-
-		// Content
-		$mail->isHTML(true);					// Set email format to HTML
-		$mail->Subject = $subject;
-		$mail->Body    = $message;
-
-		$mail->send();
-	}
-	catch (Exception $e)
-	{
-		header("HTTP/1.1 500 Internal Server Error");
-		echo "Mailer error";
-		error_log($mail->ErrorInfo);
-	}
-}
-
-function makeRequest($query)
-{
-	global $conn;
-	
-	//Make the request
-	$result = mysqli_query($conn, $query);
-	checkError();
-	if($result)
-	{
-		//If we get back a boolean, we're done
-		if (gettype($result) == 'boolean')
-		{
-			return "";
-		}
-		//If we have results, send them as a JSON array. Otherwise,
-		//send back an empty array
-		header('Content-Type: application/json');
-		$resultArr = [];
-		while($row = mysqli_fetch_assoc($result))
-		{
-			array_push($resultArr, $row);
-		}
-		return $resultArr;
-	}
-	else
-	{
-		header("HTTP/1.1 500 Internal Server Error");
-		error_log(mysqli_error($conn));
-		echo "Database Error";
-		exit;
-	}
-}
-
-function activate($RCSid)
-{
-	global $conn;
-
-	$tempPass = genPassword();
-	$statement = $conn->prepare('UPDATE students SET Status = "Active", Password = "' . password_hash($tempPass, PASSWORD_BCRYPT) . '" WHERE RCSid = ?');
-	$statement->bind_param('s', $RCSid);
-	$statement->execute();
-	checkError();
-	activatedEmail($RCSid, $tempPass);
-}
-
-// Create connection
-$conn = mysqli_connect($servername, $username, $password, $dbname);
-
-// Check connection
-if (!$conn)
-{
-	header("HTTP/1.1 500 Internal Server Error");
-	error_log(mysqli_error($conn));
-	echo "Database Error";
-	exit;
-}
 
 //Server requests are differentiated by request method
 if ($_SERVER['REQUEST_METHOD'] === 'GET')
 {
 	//Because all calls to /api/* are redirected here, we must
 	//decide which call we're actually making
-	$query = '';
 	switch($_SERVER['REQUEST_URI'])
 	{
-	case '/api/active_user':
+	case '/api/get_users':
 		adminAuthenticate();
-		$query = 'SELECT RCSid, Status FROM students WHERE Status = "Active"';
-		break;
-	case '/api/inactive_user':
-		adminAuthenticate();
-		$query = 'SELECT RCSid, Status FROM students WHERE Status = "Request"';
+		$query = '
+		SELECT
+			rcsid,
+			enabled
+		FROM
+			users
+		WHERE
+			admin = 0';
+		//Output the result
+		dumpRequest($query);
 		break;
 	case '/api/addAll':
 		$admin = adminAuthenticate();
 		error_log("Admin " . $admin . " added all students to active");
-		$query = 'SELECT RCSid FROM students WHERE Status = "Request"';
+		$query = '
+		SELECT 
+			rcsid
+		FROM 
+			users
+		WHERE
+			enabled = 0 AND
+			admin = 0';
 		$results = makeRequest($query);
 		foreach($results as $name)
 		{
-			activate($name);
+			$tempPass = resetPassword($name);
+			activatedEmail($name, $tempPass);
 		}
-		exit;
+		break;
 	case '/api/get-complaints':
 		adminAuthenticate();
 		$query = 'SELECT * FROM complaints';
+		//Output the result
+		dumpRequest($query);
 		break;
 	case '/api/get-doors':
 		$query = 'SELECT name, location, latitude, longitude, mac FROM doors';
+		//Output the result
+		dumpRequest($query);
 		break;
 	case '/api/renew-token':
-		header('Content-Type: application/json');
-		$admin = authenticate($adminPublic);
-		$user = authenticate($userPublic);
-		if($admin != "")
+		$token = getToken();
+		$user = authenticate("login", $token);
+		if($user == NULL)
 		{
-			//Check if user exists in database
-			$statement = $conn->prepare('SELECT username FROM admin WHERE username = ?');
-			$statement->bind_param('s', $admin);
-			$statement->execute();
-			checkError();
-			$result = $statement->get_result();
-			if($result)
-			{
-				if(mysqli_num_rows($result) > 0)
-				{
-					error_log("Admin " . $admin . " renewed their token");
-					$token = generateJWT($adminPrivate, $admin, $adminDuration);
-					echo json_encode(["SESSIONID"=>strval($token)]);
-					exit;
-				}
-			}
+			header("HTTP/1.1 401 Unauthorized");
+			echo "Unauthorized";
+			break;
 		}
-		else if($user != "")
+		$query = 'UPDATE tokens SET expiration = ADDDATE(UTC_TIMESTAMP, INTERVAL ? SECOND) WHERE value = ?';
+		$duration = $userDuration;
+		if($user['admin'])
 		{
-			//Check if user exists in database
-			$statement = $conn->prepare('SELECT Status FROM students WHERE Status = "Active" AND RCSid = ?');
-			$statement->bind_param('s', $user);
-			$statement->execute();
-			checkError();
-			$result = $statement->get_result();
-			if($result)
-			{
-				if(mysqli_num_rows($result) > 0)
-				{
-					error_log("User " . $user . " renewed their token");
-					$token = generateJWT($userPrivate, $user, $userDuration);
-					echo json_encode(["SESSIONID"=>strval($token)]);
-					exit;
-				}
-			}
+			$duration = $adminDuration;
 		}
-		//If no such user exists, send back an empty SESSIONID
-		echo json_encode(["SESSIONID"=>""]);
-		exit;
+		$statement = $conn->prepare($query);
+		$statement->bind_param('is', $duration, $token);
+		$statement->execute();
+		error_log('Renewed token for ' . $user['rcsid']);
+		checkError();
+		break;
 	case '/api/forgot-password':
-		$user = jwtAuthenticate($resetUserPublic, $_GET['token']);
-		if($user != "")
+		$token = $_GET['token'];
+		$user = authenticate("forgot-passwd", $_GET['token']);
+		if($user != NULL)
 		{
-			//Check if user exists in database
-			$statement = $conn->prepare('SELECT Status FROM students WHERE Status = "Active" AND RCSid = ?');
-			$statement->bind_param('s', $user);
-			$statement->execute();
-			checkError();
-			$result = $statement->get_result();
-			if($result)
-			{
-				if(mysqli_num_rows($result) > 0)
-				{
-					error_log("User " . $user . " reset their password");
-					$tempPass = genPassword();
-					$statement = $conn->prepare('UPDATE students SET Password = "' . password_hash($tempPass, PASSWORD_BCRYPT) . '" WHERE RCSid = ?');
-					$statement->bind_param('s', $user);
-					$statement->execute();
-					checkError();
-					resetPasswordEmail($user, $tempPass);
-				}
-			}
+			error_log("User " . $user['rcsid'] . " reset their password");
+			$tempPass = resetPassword($user['rcsid']);
+			resetPasswordEmail($user, $tempPass);
 		}
 		header("Location: https://rpiadc.com/");
-		exit;
+		break;
 
 	//If we don't know this call, tell our client
 	default:
 		header("HTTP/1.1 400 Bad Request");
 		echo "Unknown API call";
 		error_log("Unknown API call: GET " . $_SERVER['REQUEST_URI']);
-		exit;
 	}
-	//Output the result
-	echo json_encode(makeRequest($query));
 }
 else if ($_SERVER['REQUEST_METHOD'] === 'POST')
 {
@@ -460,65 +106,47 @@ else if ($_SERVER['REQUEST_METHOD'] === 'POST')
 	switch($_SERVER['REQUEST_URI'])
 	{
 	case '/api/login':
-		if(!userLogin($postData['RCSid'], $postData['password']))
-		{
-			//If no such user exists, send back an empty SESSIONID
-			header('Content-Type: application/json');
-			echo json_encode(["SESSIONID"=>""]);
-			exit;
-		}
-		//If this user exists, generate a JWT for client
-		$token = generateJWT($userPrivate, $postData['RCSid'], $userDuration);
-		checkError();
-		//Send the token to the client
 		header('Content-Type: application/json');
-		echo json_encode(["SESSIONID"=>strval($token)]);
-		break;
-	case '/api/admin/login':
-		if(!adminLogin($postData['username'], $postData['password']))
+		//If no such user exists, send back an empty SESSIONID
+		$token = "";
+		if(login($postData['rcsid'], $postData['password']))
 		{
-			//If no such admin exists, send back an empty SESSIONID
-			header('Content-Type: application/json');
-			echo json_encode(["SESSIONID"=>""]);
-			exit;
+			//If this user exists, generate a JWT for client
+			$token = generateToken($postData['rcsid'], "login", $userDuration);
 		}
-		//If this admin exists and the passwords match, generate a JWT
-		$token = generateJWT($adminPrivate, $postData['username'], $adminDuration);
-		checkError();
 		//Send the token to the client
-		header('Content-Type: application/json');
-		echo json_encode(["SESSIONID"=>strval($token)]);
+		echo json_encode(["SESSIONID"=>$token]);
 		break;
 	case '/api/request-access':
-		error_log("Access request with RCSid " . $postData['RCSid']);
+		error_log("Access request with rcsid " . $postData['rcsid']);
 		//Insert a new student with Status Request and RSCid passed to us
-		$statement = $conn->prepare('INSERT INTO students (RCSid, Status, Password) VALUES (?, "Request", "")');
-		$statement->bind_param('s', $postData['RCSid']);
+		$statement = $conn->prepare('INSERT INTO users (rcsid, password, admin, enabled) VALUES (?, "", 0, 0)');
+		$statement->bind_param('s', $postData['rcsid']);
 		$statement->execute();
 		checkError();
-		confirmationEmail($postData['RCSid']);
+		confirmationEmail($postData['rcsid']);
 		break;
 	case '/api/addtoActive':
 		//Check if user is an admin
 		$admin = adminAuthenticate();
-		error_log("Admin " . $admin . " added user " . $postData['RCSid'] . " to active");
+		error_log("Admin " . $admin . " added user " . $postData['rcsid'] . " to active");
 		//If they are, change Status of user with RCSid passed to us to Active
-		activate($postData['RCSid']);
+		activate($postData['rcsid']);
 		break;
 	case '/api/remove':
 		//Check if user is an admin
 		$admin = adminAuthenticate();
-		error_log("Admin " . $admin . " removed user " . $postData['RCSid']);
+		error_log("Admin " . $admin . " removed user " . $postData['rcsid']);
 		//If they are, remove user with RCSid passed to us from db
-		$statement = $conn->prepare('DELETE FROM students WHERE RCSid = ?');
-		$statement->bind_param('s', $postData['RCSid']);
+		$statement = $conn->prepare('DELETE FROM students WHERE rcsid = ? AND admin = 0');
+		$statement->bind_param('s', $postData['rcsid']);
 		$statement->execute();
 		checkError();
 		break;
 	case '/api/submit-complaint':
 		//Insert a new complaint with location and message passed to us
 		$statement = $conn->prepare('INSERT INTO complaints (location, message) VALUES (?, ?)');
-		$statement->bind_param('ss', $postData['Location'], $postData['Message']);
+		$statement->bind_param('ss', $postData['location'], $postData['message']);
 		$statement->execute();
 		checkError();
 		break;
@@ -532,91 +160,61 @@ else if ($_SERVER['REQUEST_METHOD'] === 'POST')
 		$statement->execute();
 		$result = $statement->get_result();
 		checkError();
-		if($result)
+		if(mysqli_num_rows($result) > 0)
 		{
-			if(mysqli_num_rows($result) > 0)
-			{
-				//If we get the key, generate a TOTP from the key
-				//and send it to the client
-				$secret = mysqli_fetch_assoc($result)['key'];
-				$otp = TOTP::create($secret, 30, 'sha1', 6);
-				echo json_encode(['TOTP'=>strval($otp->now())]);
-			}
-			else
-			{
-				header("HTTP/1.1 400 Bad Request");
-				error_log("No such door");
-				echo "Door not found";
-			}
+			//If we get the key, generate a TOTP from the key
+			//and send it to the client
+			$secret = mysqli_fetch_assoc($result)['key'];
+			$otp = TOTP::create($secret, 30, 'sha1', 6);
+			echo json_encode(['TOTP'=>strval($otp->now())]);
 		}
 		else
 		{
-			header("HTTP/1.1 500 Internal Server Error");
-			error_log(mysqli_error($conn));
-			echo "Database Error";
+			header("HTTP/1.1 400 Bad Request");
+			error_log("No such door");
+			echo "Door not found";
 		}
 		break;
 	case '/api/change-password':
 		//Check if credentials are correct
-		if(!userLogin($postData['RCSid'], $postData['password']))
+		if(!login($postData['rcsid'], $postData['password']))
 		{
 			echo "Bad credentials";
 			exit;
 		}
 		//Create statement and hash password
-		$statement = $conn->prepare('UPDATE students SET Password = ? WHERE RCSid = ?');
-		$newPass = password_hash($postData['newPassword'], PASSWORD_BCRYPT);
-		$statement->bind_param('ss', $newPass, $postData['RCSid']);
+		$statement = $conn->prepare('UPDATE users SET password = ? WHERE rcsid = ?');
+		$newPass = password_hash($postData['newpass'], PASSWORD_BCRYPT);
+		$statement->bind_param('ss', $newPass, $postData['rcsid']);
 		$statement->execute();
+		error_log("Changed password for " . $postData['rcsid']);
 		checkError();
-		$result = $statement->get_result();
-		error_log("Changed password for user " . $postData['RCSid']);
 		//If we failed, tell them. Otherwise, success
-		passwordChangeEmail($postData['RCSid']);
-		break;
-	case '/api/admin/change-password':
-		//Check if credentials are correct
-		if(!adminLogin($postData['username'], $postData['password']))
-		{
-			echo "Bad credentials";
-			exit;
-		}
-		//Create statement and hash password
-		$statement = $conn->prepare('UPDATE admin SET password = ? WHERE username = ?');
-		$newPass = password_hash($postData['newPassword'], PASSWORD_BCRYPT);
-		$statement->bind_param('ss', $newPass, $postData['username']);
-		$statement->execute();
-		checkError();
-		$result = $statement->get_result();
-		error_log("Changed password for admin " . $postData['username']);
+		passwordChangeEmail($postData['rcsid']);
 		break;
 	case '/api/reset-password':
 		//Check if user is an admin
 		$admin = adminAuthenticate();
-		//If the are, create the statement and hash password
-		error_log("Admin " . $admin . " reset password for user " . $postData['RCSid']);
-		$statement = $conn->prepare('UPDATE students SET Password = ? WHERE RCSid = ?');
-		$newPass = password_hash($postData['newPassword'], PASSWORD_BCRYPT);
-		$statement->bind_param('ss', $newPass, $postData['RCSid']);
+		//If they are, create the statement and hash password
+		error_log("Admin " . $admin . " reset password for user " . $postData['rcsid']);
+		$statement = $conn->prepare('UPDATE users SET password = ? WHERE rcsid = ? AND admin = 0');
+		$newPass = password_hash($postData['newpass'], PASSWORD_BCRYPT);
+		$statement->bind_param('ss', $newPass, $postData['rcsid']);
 		$statement->execute();
 		checkError();
-		$result = $statement->get_result();
 		break;
 	case '/api/forgot-password':
-		error_log("User " . $postData['RCSid'] . " forgot their password");
-		$statement = $conn->prepare('SELECT * FROM students WHERE RCSid = ? AND STATUS = "Active"');
-		$statement->bind_param('s', $RCSid);
+		error_log("User " . $postData['rcsid'] . " forgot their password");
+		$statement = $conn->prepare('SELECT * FROM users WHERE rcsid = ? AND enabled = 1');
+		$statement->bind_param('s', $postData['rcsid']);
 		$statement->execute();
 		checkError();
 		$result = $statement->get_result();
-		if($result)
+		if($result && mysqli_num_rows($result) > 0)
 		{
-			if(mysqli_num_rows($result) > 0)
-			{
-				forgotPasswordEmail($postData['RCSid']);
-			}
+			forgotPasswordEmail($postData['RCSid']);
 		}
-		exit;
+		break;
 	default:
 		header("HTTP/1.1 400 Bad Request");
 		echo "Unknown API call";

--- a/api/index.php
+++ b/api/index.php
@@ -32,7 +32,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET')
 		//Output the result
 		dumpRequest($query);
 		break;
-	case '/api/addAll':
+	case '/api/add_all':
 		$admin = adminAuthenticate();
 		error_log("Admin " . $admin . " added all students to active");
 		$query = '
@@ -50,18 +50,18 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET')
 			activatedEmail($name, $tempPass);
 		}
 		break;
-	case '/api/get-complaints':
+	case '/api/get_complaints':
 		adminAuthenticate();
 		$query = 'SELECT * FROM complaints';
 		//Output the result
 		dumpRequest($query);
 		break;
-	case '/api/get-doors':
+	case '/api/get_doors':
 		$query = 'SELECT name, location, latitude, longitude, mac FROM doors';
 		//Output the result
 		dumpRequest($query);
 		break;
-	case '/api/renew-token':
+	case '/api/renew_token':
 		$token = getToken();
 		$user = authenticate("login", $token);
 		if($user == NULL)
@@ -77,7 +77,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'GET')
 		error_log('Renewed token for ' . $user['rcsid']);
 		checkError();
 		break;
-	case '/api/forgot-password':
+	case '/api/forgot_password':
 		$token = $_GET['token'];
 		$user = authenticate("forgot-passwd", $_GET['token']);
 		if($user != NULL)
@@ -125,7 +125,7 @@ else if ($_SERVER['REQUEST_METHOD'] === 'POST')
 		//Send the token to the client
 		echo json_encode(["SESSIONID"=>$token]);
 		break;
-	case '/api/request-access':
+	case '/api/request_access':
 		error_log("Access request with rcsid " . $postData['rcsid']);
 		//Insert a new student with Status Request and RSCid passed to us
 		$statement = $conn->prepare('INSERT INTO users (rcsid, password, admin, enabled) VALUES (?, "", 0, 0)');
@@ -134,7 +134,7 @@ else if ($_SERVER['REQUEST_METHOD'] === 'POST')
 		checkError();
 		confirmationEmail($postData['rcsid']);
 		break;
-	case '/api/addtoActive':
+	case '/api/add_to_active':
 		//Check if user is an admin
 		$admin = adminAuthenticate();
 		error_log("Admin " . $admin . " added user " . $postData['rcsid'] . " to active");
@@ -151,14 +151,14 @@ else if ($_SERVER['REQUEST_METHOD'] === 'POST')
 		$statement->execute();
 		checkError();
 		break;
-	case '/api/submit-complaint':
+	case '/api/submit_complaint':
 		//Insert a new complaint with location and message passed to us
 		$statement = $conn->prepare('INSERT INTO complaints (location, message) VALUES (?, ?)');
 		$statement->bind_param('ss', $postData['location'], $postData['message']);
 		$statement->execute();
 		checkError();
 		break;
-	case '/api/open-door':
+	case '/api/open_door':
 		//Check if client is a user
 		$user = userAuthenticate();
 		error_log("User " . $user . " opened door " . $postData['door']);
@@ -183,7 +183,7 @@ else if ($_SERVER['REQUEST_METHOD'] === 'POST')
 			echo "Door not found";
 		}
 		break;
-	case '/api/change-password':
+	case '/api/change_password':
 		//Check if credentials are correct
 		if(!login($postData['rcsid'], $postData['password']))
 		{
@@ -200,7 +200,7 @@ else if ($_SERVER['REQUEST_METHOD'] === 'POST')
 		//If we failed, tell them. Otherwise, success
 		passwordChangeEmail($postData['rcsid']);
 		break;
-	case '/api/reset-password':
+	case '/api/reset_password':
 		//Check if user is an admin
 		$admin = adminAuthenticate();
 		//If they are, create the statement and hash password
@@ -211,7 +211,7 @@ else if ($_SERVER['REQUEST_METHOD'] === 'POST')
 		$statement->execute();
 		checkError();
 		break;
-	case '/api/forgot-password':
+	case '/api/forgot_password':
 		error_log("User " . $postData['rcsid'] . " forgot their password");
 		$statement = $conn->prepare('SELECT * FROM users WHERE rcsid = ? AND enabled = 1');
 		$statement->bind_param('s', $postData['rcsid']);


### PR DESCRIPTION
This PR standardizes API call formats, replaces the JWT token format with a simple 128 bit hex encoded random token, and has a lot of cleanup. This is a breaking change, as it removes the /admin endpoints and integrates them fully with the normal endpoints. This means that admin logins are handled through /login and so on, so clients will fail if setup for the previous version. In addition, it specifies a new database layout, and again the old layout will not work. Do not merge until clients are updated. 